### PR TITLE
Drop support for indefinite length in DER

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
@@ -327,7 +327,7 @@ internal object Adapters {
         val adapter = chooser(reader.typeHint) as DerAdapter<Any?>?
         return when {
           adapter != null -> adapter.fromDer(reader)
-          else -> reader.readOctetString()
+          else -> reader.readUnknown()
         }
       }
     }
@@ -393,7 +393,7 @@ internal object Adapters {
         }
 
         reader.read("ANY") { header ->
-          val bytes = reader.readOctetString()
+          val bytes = reader.readUnknown()
           return AnyValue(
               tagClass = header.tagClass,
               tag = header.tag,


### PR DESCRIPTION
This is a feature of ASN.1 that DER doesn't use, and in fact it forbids.