### PR TITLE
Push OkHttp 3.14.x into the sea. It is no longer supported.

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,6 @@ Security Policy
 | Version | Supported        | Notes          |
 | ------- | ---------------- | -------------- |
 | 4.x     | ✅               |  Android 5.0+ (API level 21+) and on Java 8+. |
-| 3.14.x  | Until 2020-06-30 |                |
 | 3.12.x  | Until 2021-12-31 | Android 2.3+ (API level 9+) and Java 7+. Platforms may not support TLSv1.2. |
 
 


### PR DESCRIPTION
OkHttp 4.x is our only branch receiving security fixes, bug fixes, and
new features.

OkHttp 3.12.x gets security fixes only.